### PR TITLE
Fix img at NPM Readme

### DIFF
--- a/eslint-config-quintoandar-pwa/README.md
+++ b/eslint-config-quintoandar-pwa/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img width="450" height="76" vspace="" hspace="25" src="../eslint-config-quintoandar.png">
+  <img width="450" height="76" vspace="" hspace="25" src="https://github.com/quintoandar/eslint-config-quintoandar/blob/master/eslint-config-quintoandar.png?raw=true">
   <h1>eslint-config-quintoandar-pwa</h1>
 </div>
 


### PR DESCRIPTION
## What does this PR do?

- Fix img at npm readme putting the whole image url 

### Before
![image](https://user-images.githubusercontent.com/8939619/43197584-f923529e-8fe1-11e8-9b9c-75b925260699.png)


