### PR TITLE
Try to fix vscode error because of spread operator

### DIFF
--- a/eslint-config-quintoandar-pwa/CHANGELOG.md
+++ b/eslint-config-quintoandar-pwa/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Features
 
---
+- Add eslint custom rules as internal plugin [#14](https://github.com/quintoandar/eslint-config-quintoandar/pull/14)
 
 ### Fixes
 
 - Fix image ref in npm readme [#12](https://github.com/quintoandar/eslint-config-quintoandar/pull/12)
+
+- Fix vscode error to read `.eslintrc` with spread operator [#16](https://github.com/quintoandar/eslint-config-quintoandar/pull/16)
 
 ### Chore & Maintenance
 

--- a/eslint-config-quintoandar-pwa/rules/index.js
+++ b/eslint-config-quintoandar-pwa/rules/index.js
@@ -41,6 +41,6 @@ const rules = {
   'require-yield': OFF,
 };
 
-const concatanedRules = Object.assign(rules, importRules, reactRules, jsxRules);
+const concatenatedRules = Object.assign({}, rules, importRules, reactRules, jsxRules);
 
-module.exports = concatanedRules;
+module.exports = concatenatedRules;

--- a/eslint-config-quintoandar-pwa/rules/index.js
+++ b/eslint-config-quintoandar-pwa/rules/index.js
@@ -3,7 +3,7 @@ const reactRules = require('./react');
 const jsxRules = require('./jsx');
 const { OFF, WARN, ERROR } = require('./constants').CONFIG_RULES;
 
-module.exports = {
+const rules = {
   'arrow-parens': [
     'error',
     'always'
@@ -39,7 +39,8 @@ module.exports = {
   'prefer-template': ERROR,
   'class-methods-use-this': OFF,
   'require-yield': OFF,
-  ...importRules,
-  ...reactRules,
-  ...jsxRules,
 };
+
+const concatanedRules = Object.assign(rules, importRules, reactRules, jsxRules);
+
+module.exports = concatanedRules;


### PR DESCRIPTION
## What does this PR do?

- Try to fix the vscode error because of spread operator in `.eslintrc`

Fix reported by: @lucaspg. Tks! 

https://github.com/Microsoft/vscode-eslint/issues/345