### PR TITLE
Add quintoandar plugin as peer dep

### DIFF
--- a/eslint-config-quintoandar-pwa/index.js
+++ b/eslint-config-quintoandar-pwa/index.js
@@ -14,6 +14,7 @@ module.exports = {
   plugins: [
     'react',
     'jsx-a11y',
+    'quintoandar'
   ],
 
   parserOptions: {

--- a/eslint-config-quintoandar-pwa/package-lock.json
+++ b/eslint-config-quintoandar-pwa/package-lock.json
@@ -2045,6 +2045,12 @@
         "object-assign": "4.1.1"
       }
     },
+    "eslint-plugin-quintoandar": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-quintoandar/-/eslint-plugin-quintoandar-1.0.0.tgz",
+      "integrity": "sha512-N7VDsoWjNNFl5tdpXIydGmES5T403cuCVn/wxQ2iQiQa4s2nonUKMRISO7/0ylsEJ4K9rv8oQNQOjuLkyPcGIQ==",
+      "dev": true
+    },
     "eslint-plugin-react": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.7.1.tgz",

--- a/eslint-config-quintoandar-pwa/package.json
+++ b/eslint-config-quintoandar-pwa/package.json
@@ -31,6 +31,8 @@
     "eslint-import-resolver-webpack": "0.8.0",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jsx-a11y": "2.2.3",
+    "eslint-plugin-quintoandar": "^1.0.0",
+
     "eslint-plugin-react": "6.7.1"
   },
   "devDependencies": {
@@ -41,6 +43,7 @@
     "eslint-import-resolver-webpack": "0.8.0",
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-jsx-a11y": "2.2.3",
+    "eslint-plugin-quintoandar": "^1.0.0",
     "eslint-plugin-react": "6.7.1",
     "jest": "^23.4.1"
   },

--- a/eslint-config-quintoandar-pwa/tests/index.test.js
+++ b/eslint-config-quintoandar-pwa/tests/index.test.js
@@ -20,7 +20,7 @@ describe('Eslint shareable config', () => {
   });
 
   it('plugins should have correct array value', () => {
-    expect(config.plugins).toEqual(['react', 'jsx-a11y']);
+    expect(config.plugins).toEqual(['react', 'jsx-a11y', 'quintoandar']);
   });
 
   it('parserOptions should have correct object value', () => {


### PR DESCRIPTION
## What does this PR do?

- add quintoandar plugin as peer dep to reuse when use eslint-config-quintoandar-pwa