### PR TITLE
Create no-dynamic-import-index rule

### DIFF
--- a/eslint-plugin-quintoandar/CHANGELOG.md
+++ b/eslint-plugin-quintoandar/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## master
 
+## 1.1.0 - no-dynamic-import-index rule
+
+### Features
+
+- Create no-dynamic-import-index rule to disallow dynamic imports of 'index' files, i.e. `import('./index')`, `import('../index')`
+
 ## 1.0.1 - Fixes in readme
 
 ### Fixes

--- a/eslint-plugin-quintoandar/README.md
+++ b/eslint-plugin-quintoandar/README.md
@@ -5,21 +5,20 @@
 
 ## Table of Contents
 
-* [Getting start](#getting-start)
+* [Getting started](#getting-started)
 * [Rules](#rules)
 * [Versioning](#versioning)
 * [Contributing](#contributing)
 
-## Getting start
+## Getting started
 
-This package provides QuintoAndar's custom eslint rules, that are created by our engineer's demand.
+This package provides QuintoAndar's custom eslint rules, that are created by our engineers' demand.
 All these rules are accessible in the eslint config that is plugged in. For example, the package `eslint-config-quintoandar-pwa` uses it as a plugin.
 
 These custom rules can be used in two ways:
 
 - use directly, applying to everybody
-- use new custom rule progressive
-
+- use new custom rule progressively
 
 ### How to add in a project as an eslint plugin
 
@@ -47,6 +46,18 @@ or
 
 ## Rules
 
+### No dynamic import index
+
+Do not allow dynamically importing `index` files i.e. `import('./index')`, `import('../index')`. This rule was created because if multiple [react-loadable](https://github.com/jamiebuilds/react-loadable) components used the same path in the `import()` call, it would cause problems during chunk resolution and a page would load more JS chunks than necessary. Since most of the problems arose with multiple files named 'index', this rules suggests to rename them with a more specific name.
+
+#### How to use it
+
+Just add the code below in your rules array:
+
+```js
+"quintoandar/no-dynamic-import-index": 2,
+```
+
 ### No target blank
 
 Do not allow the usage of `target="_blank"` without `rel="noopener noreferrer` because of a security problem.
@@ -56,7 +67,7 @@ Do not allow the usage of `target="_blank"` without `rel="noopener noreferrer` b
 Just add the code below in your rules array:
 
 ```js
-"internal/no-target-blank": 2,
+"quintoandar/no-target-blank": 2,
 ```
 
 ### No typo components
@@ -65,7 +76,7 @@ Create a new custom rule is also a way to move from the deprecated approach to n
 
 #### How to use it
 
-Just add the code below in your rules array
+Just add the code below in your rules array:
 
 ```js
 "quintoandar/no-typo-components": 2,

--- a/eslint-plugin-quintoandar/index.js
+++ b/eslint-plugin-quintoandar/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 module.exports = {
   rules: {
+    'no-dynamic-import-index': require('./rules/no-dynamic-import-index'),
     'no-target-blank': require('./rules/no-target-blank'),
     'no-typo-components': require('./rules/no-typo-components'),
   },

--- a/eslint-plugin-quintoandar/package-lock.json
+++ b/eslint-plugin-quintoandar/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/eslint-plugin-quintoandar/package.json
+++ b/eslint-plugin-quintoandar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "An eslint-plugin for PWA-Tenants custom rules",
   "main": "index.js",
   "scripts": {

--- a/eslint-plugin-quintoandar/rules/no-dynamic-import-index.js
+++ b/eslint-plugin-quintoandar/rules/no-dynamic-import-index.js
@@ -1,9 +1,8 @@
-const message = 'Do not dynamically import "index" files, give them a more unique name instead. ' +
-  'Duplicated import() strings across a project may cause problems with react-loadable ' +
-  'requesting more chunks than necessary.';
+const message = `Do not dynamically import "index" files, give them a more unique name instead.
+Duplicated import() strings across a project may cause problems with react-loadable requesting more chunks than necessary.`;
 
 // Match strings ending in '/index' with optional extension
-const re = /.*\/index(\..*)?$/;
+const indexFileRegex = /.*\/index(\..*)?$/;
 
 module.exports = {
   meta: {
@@ -16,7 +15,7 @@ module.exports = {
   create: function noDynamicImportIndex(context) {
     return {
       CallExpression(node) {
-        if (node.callee.type === 'Import' && node.arguments.some((arg) => re.test(arg.value))) {
+        if (node.callee.type === 'Import' && node.arguments.some((arg) => indexFileRegex.test(arg.value))) {
           context.report({ node, message });
         }
       },

--- a/eslint-plugin-quintoandar/rules/no-dynamic-import-index.js
+++ b/eslint-plugin-quintoandar/rules/no-dynamic-import-index.js
@@ -1,0 +1,25 @@
+const message = 'Do not dynamically import "index" files, give them a more unique name instead. ' +
+  'Duplicated import() strings across a project may cause problems with react-loadable ' +
+  'requesting more chunks than necessary.';
+
+// Match strings ending in '/index' with optional extension
+const re = /.*\/index(\..*)?$/;
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow dynamically importing "index" files',
+      category: 'Best Practices',
+    },
+  },
+  create: function noDynamicImportIndex(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === 'Import' && node.arguments.some((arg) => re.test(arg.value))) {
+          context.report({ node, message });
+        }
+      },
+    };
+  },
+};

--- a/eslint-plugin-quintoandar/rules/tests/no-dynamic-import-index.test.js
+++ b/eslint-plugin-quintoandar/rules/tests/no-dynamic-import-index.test.js
@@ -19,9 +19,8 @@ const parserOptions = {
 // Tests
 // ------------------------------------------------------------------------------
 
-const message = 'Do not dynamically import "index" files, give them a more unique name instead. ' +
-  'Duplicated import() strings across a project may cause problems with react-loadable ' +
-  'requesting more chunks than necessary.';
+const message = `Do not dynamically import "index" files, give them a more unique name instead.
+Duplicated import() strings across a project may cause problems with react-loadable requesting more chunks than necessary.`;
 
 const errors = [{ message }];
 

--- a/eslint-plugin-quintoandar/rules/tests/no-dynamic-import-index.test.js
+++ b/eslint-plugin-quintoandar/rules/tests/no-dynamic-import-index.test.js
@@ -1,0 +1,45 @@
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../no-dynamic-import-index');
+const RuleTester = require('eslint').RuleTester;
+
+const parser = 'babel-eslint'; // import() is an experimental syntax
+const parserOptions = {
+  ecmaVersion: 8,
+  sourceType: 'module',
+  ecmaFeatures: {
+    experimentalObjectRestSpread: true,
+    jsx: true,
+  },
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const message = 'Do not dynamically import "index" files, give them a more unique name instead. ' +
+  'Duplicated import() strings across a project may cause problems with react-loadable ' +
+  'requesting more chunks than necessary.';
+
+const errors = [{ message }];
+
+const ruleTester = new RuleTester({ parser, parserOptions });
+ruleTester.run('no-dynamic-import-index', rule, {
+  valid: [
+    { code: "import('./MyComponent')" },
+    { code: "import('MyModule/index/MyComponent')" },
+    { code: "() => import(/* webpackChunkName: \"searchListMode\" */ './SearchList')" },
+  ],
+  invalid: [
+    { code: "import('./index')", errors },
+    { code: "import('./index.js')", errors },
+    { code: "import('./index.jsx')", errors },
+    { code: "import('./index.ts')", errors },
+    { code: "import('../index')", errors },
+    { code: "import('../../../index')", errors },
+    { code: "import('MyModule/MyComponent/index')", errors },
+    { code: "() => import(/* webpackChunkName: \"NextStepsDialog\" */'./index')", errors },
+  ],
+});


### PR DESCRIPTION
Adds new rule to eslint-plugin-quintoandar, `no-dynamic-import-index`. This rule does not allow dynamically importing 'index' files, i.e. `import('./index')` or `import('../index.js')`.

**Why?** The listing page of pwa-tenants was loading way more js chunks than necessary. This is because multiple react-loadable components imported `'./index'` files and duplicate import paths like these caused problems when resolving which chunks to load.

![captura de tela 2018-10-26 as 15 34 55](https://user-images.githubusercontent.com/12578347/49308408-5b26cb00-f4bf-11e8-837b-f0d915f16ac7.png)

**Considerations:** so far, we only had issues with 'index' imports, that's why it's the only covered case here. The idea is to fix this issue in each project by renaming the files to use a more specific name and then adding this rule to their eslint config.