### PR TITLE
(fix) Include processors folder (v1.5.4)

### DIFF
--- a/eslint-plugin-quintoandar/package-lock.json
+++ b/eslint-plugin-quintoandar/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/eslint-plugin-quintoandar/package.json
+++ b/eslint-plugin-quintoandar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "An eslint-plugin for PWA-Tenants custom rules",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,8 @@
   },
   "files": [
     "index.js",
-    "rules"
+    "rules",
+    "processors"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
# What this PR do

- Include `processors` folder for package publication

## Why

The folder is currently not being published

![image](https://user-images.githubusercontent.com/11169832/57414190-854a8a80-71cd-11e9-9ee5-4669a0266383.png)
