### PR TITLE
COZY-227 - Add lint rule for dimens import

### DIFF
--- a/eslint-plugin-quintoandar/index.js
+++ b/eslint-plugin-quintoandar/index.js
@@ -14,6 +14,7 @@ module.exports = {
     'no-themeprovider-import': require('./rules/no-themeprovider-import'),
     'no-mui-import': require('./rules/no-mui-import'),
     'no-direct-icons-import': require('./rules/no-direct-icons-import'),
+    'no-dimens-import': require('./rules/no-dimens-import'),
   },
   configs: {
     recommended: {
@@ -27,6 +28,7 @@ module.exports = {
         'no-themeprovider-import': 2,
         'no-mui-import': 2,
         'no-direct-icons-import': 2,
+        'no-dimens-import': 2,
       },
     },
   },

--- a/eslint-plugin-quintoandar/package-lock.json
+++ b/eslint-plugin-quintoandar/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/eslint-plugin-quintoandar/package.json
+++ b/eslint-plugin-quintoandar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "An eslint-plugin for PWA-Tenants custom rules",
   "main": "index.js",
   "scripts": {

--- a/eslint-plugin-quintoandar/rules/no-dimens-import.js
+++ b/eslint-plugin-quintoandar/rules/no-dimens-import.js
@@ -1,0 +1,21 @@
+const DimensPath = 'assets/values/dimens';
+
+const reportText = `
+  Do not import Dimens.
+  Use material-ui's Box component instead. (block-party/components/Box)
+  https://material-ui.com/system/spacing/
+`;
+
+module.exports = function noDimensImport(context) {
+  const checkString = (node, string) => node.indexOf(string) >= 0;
+  return {
+    ImportDeclaration(node) {
+      if (checkString(node.source.value, DimensPath)) {
+        context.report({
+          node,
+          message: reportText,
+        });
+      }
+    }
+  };
+};

--- a/eslint-plugin-quintoandar/rules/tests/no-dimens-import.test.js
+++ b/eslint-plugin-quintoandar/rules/tests/no-dimens-import.test.js
@@ -1,0 +1,43 @@
+
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../no-dimens-import');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 8,
+  sourceType: 'module',
+  ecmaFeatures: {
+    experimentalObjectRestSpread: true,
+    jsx: true,
+  },
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const reportText = `
+  Do not import Dimens.
+  Use material-ui's Box component instead. (block-party/components/Box)
+  https://material-ui.com/system/spacing/
+`;
+
+const errors = [{ reportText }];
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('no-dimens-import', rule, {
+  valid: [{
+    code: "import Box from 'block-party/components/Box'"
+  }],
+  invalid: [{
+    code: "import Dimens from 'block-party/assets/values/dimens'",
+    errors,
+  }, {
+    code: "import Dimens from 'assets/values/dimens'",
+    errors,
+  }]
+});


### PR DESCRIPTION
## WHAT
This PR adds a new rule to prevent the use of `Dimens` import.

## WHY
We are deprecating Dimens because we found a new solution to handle spacing, using `Box` component from Material UI: https://material-ui.com/system/spacing/
`import Box from 'block-party/components/Box'`

So before we were doing:
```
const Wrapper = styled.span`	
  padding: ${({ hasSpacing }) => hasSpacing ? Dimens.defaultHalfSpacing : Dimens.noMargin};	
  text-align: center;	
`;
```
Now we can just do:
```
<Box p={hasSpacing ? 1 : 0} textAlign="center" data-testid={dataTestId}>
...
</Box>
```

> Note: The unit is `8`, the same as `theme.spacing()`. So you can use `2` to represent `16` and `0.5` to represent `4` for example.