### PR TITLE
[ALF-219] No Block-party Login import rule

### DIFF
--- a/eslint-plugin-quintoandar/rules/no-block-party-login.js
+++ b/eslint-plugin-quintoandar/rules/no-block-party-login.js
@@ -1,0 +1,19 @@
+const notAllowedLoginPathRegex = /^(block-party\/)?(containers\/Login)/;
+
+const reportText = `
+  Do not use Block-party Login container.
+  Use Bioma Auth package instead (see: https://github.com/quintoandar/bioma/tree/master/packages/auth).
+`;
+
+module.exports = function noBlockPartyLoginImport(context) {
+  return {
+    ImportDeclaration(node) {
+      if (node.source.value.match(notAllowedLoginPathRegex)) {
+        context.report({
+          node,
+          message: reportText,
+        });
+      }
+    }
+  };
+};

--- a/eslint-plugin-quintoandar/rules/tests/no-block-party-login.test.js
+++ b/eslint-plugin-quintoandar/rules/tests/no-block-party-login.test.js
@@ -1,0 +1,42 @@
+
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../no-block-party-login');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 8,
+  sourceType: 'module',
+  ecmaFeatures: {
+    experimentalObjectRestSpread: true,
+    jsx: true,
+  },
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const reportText = `
+  Do not use Block-party Login container.
+  Use Bioma Auth package instead (see: https://github.com/quintoandar/bioma/tree/master/packages/auth).
+`;
+
+const errors = [{ reportText }];
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('no-block-party-login-import', rule, {
+  valid: [
+    { code: "import Login from '@bioma/auth/containers/Login'" },
+  ],
+  invalid: [{
+    code: "import Login from 'containers/Login'",
+    errors,
+  }, {
+    code: "import Login from 'block-party/containers/Login'",
+    errors,
+  }]
+});


### PR DESCRIPTION
Once we successfully migrated the auth package in some projects we need to guarantee that the old Block-party login container will not be used anymore! Here we added a new rule to achieve this.