### PR TITLE
[ALF-219] No Block-party Login import rule missing infos

### DIFF
--- a/eslint-plugin-quintoandar/README.md
+++ b/eslint-plugin-quintoandar/README.md
@@ -172,6 +172,19 @@ Just add the code below in your rules array (preferable to a progressive-lint co
 "quintoandar/no-npm-registry": 2,
 ```
 
+### No Block-Party Login import
+
+Don't allow usage of Block-party Login container.
+Use Biomas's Auth package instead (see: see: https://github.com/quintoandar/bioma/tree/master/packages/auth).
+
+#### How to use it
+
+Just add the code below in your rules array:
+
+```js
+"quintoandar/no-block-party-login-import": 2,
+```
+
 ## Versioning
 
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [CHANGELOG.md](https://github.com/quintoandar/eslint-config-quintoandar/blob/master/eslint-plugin-quintoandar/CHANGELOG.md)

--- a/eslint-plugin-quintoandar/index.js
+++ b/eslint-plugin-quintoandar/index.js
@@ -15,6 +15,7 @@ module.exports = {
     'no-mui-import': require('./rules/no-mui-import'),
     'no-direct-icons-import': require('./rules/no-direct-icons-import'),
     'no-dimens-import': require('./rules/no-dimens-import'),
+    'no-block-party-login-import': require('./rules/no-block-party-login'),
   },
   configs: {
     recommended: {
@@ -29,6 +30,7 @@ module.exports = {
         'no-mui-import': 2,
         'no-direct-icons-import': 2,
         'no-dimens-import': 2,
+        'no-block-party-login-import': 2,
       },
     },
   },

--- a/eslint-plugin-quintoandar/package-lock.json
+++ b/eslint-plugin-quintoandar/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/eslint-plugin-quintoandar/package.json
+++ b/eslint-plugin-quintoandar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "An eslint-plugin for PWA-Tenants custom rules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In the last PR (#49) I've added a new rule that prevents devs to import the block-party Login container. Now I'm updating the docs with example usage and increased package versions according to semver.