### PR TITLE
No block-party WaffleMenu import rule

### DIFF
--- a/eslint-plugin-quintoandar/README.md
+++ b/eslint-plugin-quintoandar/README.md
@@ -185,6 +185,19 @@ Just add the code below in your rules array:
 "quintoandar/no-block-party-login-import": 2,
 ```
 
+### No Block-Party Login import
+
+Don't allow usage of Block-party WaffleMenu containers and components.
+Use Biomas's waffle-menu package instead (see: see: https://github.com/quintoandar/bioma/tree/master/packages/waffle-menu).
+
+#### How to use it
+
+Just add the code below in your rules array:
+
+```js
+"quintoandar/no-block-party-waffle-menu-import": 2,
+```
+
 ## Versioning
 
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [CHANGELOG.md](https://github.com/quintoandar/eslint-config-quintoandar/blob/master/eslint-plugin-quintoandar/CHANGELOG.md)

--- a/eslint-plugin-quintoandar/index.js
+++ b/eslint-plugin-quintoandar/index.js
@@ -31,6 +31,7 @@ module.exports = {
         'no-direct-icons-import': 2,
         'no-dimens-import': 2,
         'no-block-party-login-import': 2,
+        'no-block-party-waffle-menu-import': 2,
       },
     },
   },

--- a/eslint-plugin-quintoandar/package-lock.json
+++ b/eslint-plugin-quintoandar/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/eslint-plugin-quintoandar/package.json
+++ b/eslint-plugin-quintoandar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "An eslint-plugin for PWA-Tenants custom rules",
   "main": "index.js",
   "scripts": {

--- a/eslint-plugin-quintoandar/rules/no-block-party-waffle-menu.js
+++ b/eslint-plugin-quintoandar/rules/no-block-party-waffle-menu.js
@@ -1,0 +1,19 @@
+const notAllowedWaffleMenuPathRegex = /^(block-party\/(containers|components)\/(WaffleMenu|OwnersWaffleMenu))/;
+
+const reportText = `
+  Do not use Block-party WaffleMenu containers or components.
+  Use Bioma waffle-menu package instead (see: https://github.com/quintoandar/bioma/tree/master/packages/waffle-menu).
+`;
+
+module.exports = function noBlockPartyWaffleMenuImport(context) {
+  return {
+    ImportDeclaration(node) {
+      if (node.source.value.match(notAllowedWaffleMenuPathRegex)) {
+        context.report({
+          node,
+          message: reportText,
+        });
+      }
+    }
+  };
+};

--- a/eslint-plugin-quintoandar/rules/tests/no-block-party-waffle-menu.test.js
+++ b/eslint-plugin-quintoandar/rules/tests/no-block-party-waffle-menu.test.js
@@ -1,0 +1,46 @@
+
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../no-block-party-waffle-menu');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 8,
+  sourceType: 'module',
+  ecmaFeatures: {
+    experimentalObjectRestSpread: true,
+    jsx: true,
+  },
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const reportText = `
+  Do not use Block-party WaffleMenu containers or components.
+  Use Bioma waffle-menu package instead (see: https://github.com/quintoandar/bioma/tree/master/packages/waffle-menu).
+`;
+
+const errors = [{ reportText }];
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('no-block-party-waffle-menu-import', rule, {
+  valid: [
+    { code: "import WaffleMenu from '@bioma/waffle-menu/containers/WaffleMenu'" },
+    { code: "import WaffleMenu from '@bioma/waffle-menu/components/WaffleMenu'" },
+    { code: "import MenuButton from '@bioma/waffle-menu/components/WaffleMenu/MenuButton'" },
+    { code: "import OwnersWaffleMenu from '@bioma/waffle-menu/containers/OwnersWaffleMenu'" },
+    { code: "import OwnersWaffleMenu from '@bioma/waffle-menu/components/OwnersWaffleMenu'" },
+  ],
+  invalid: [
+    { code: "import WaffleMenu from 'block-party/containers/WaffleMenu'", errors },
+    { code: "import WaffleMenu from 'block-party/components/WaffleMenu'", errors },
+    { code: "import MenuButton from 'block-party/components/WaffleMenu/MenuButton'", errors },
+    { code: "import OwnersWaffleMenu from 'block-party/containers/OwnersWaffleMenu'", errors },
+    { code: "import OwnersWaffleMenu from 'block-party/components/OwnersWaffleMenu'", errors },
+  ]
+});


### PR DESCRIPTION
New lint rule to disallow imports from the old block-party WaffleMenu and OwnersWaffleMenu containers and components

We should use the new waffle-menu package from bioma instead