### PR TITLE
(fix) Relative index import regex

### DIFF
--- a/eslint-plugin-quintoandar/package.json
+++ b/eslint-plugin-quintoandar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "An eslint-plugin for PWA-Tenants custom rules",
   "main": "index.js",
   "scripts": {

--- a/eslint-plugin-quintoandar/rules/quintoandar-import-order.js
+++ b/eslint-plugin-quintoandar/rules/quintoandar-import-order.js
@@ -2,7 +2,7 @@ const companyPaths = '@quintoandar/';
 
 const projectAbsolutePaths = ['components/', 'containers/', 'helpers/', 'utils/'];
 
-const relativePaths = ['\\.\\.', '\\.'];
+const relativePaths = ['\\.'];
 
 const pathsUnion = [companyPaths]
   .concat(relativePaths)

--- a/eslint-plugin-quintoandar/rules/quintoandar-import-order.js
+++ b/eslint-plugin-quintoandar/rules/quintoandar-import-order.js
@@ -2,7 +2,7 @@ const companyPaths = '@quintoandar/';
 
 const projectAbsolutePaths = ['components/', 'containers/', 'helpers/', 'utils/'];
 
-const relativePaths = ['./', '../'];
+const relativePaths = ['\\.\\.', '\\.'];
 
 const pathsUnion = [companyPaths]
   .concat(relativePaths)

--- a/eslint-plugin-quintoandar/rules/tests/quintoandar-import-order.test.js
+++ b/eslint-plugin-quintoandar/rules/tests/quintoandar-import-order.test.js
@@ -49,6 +49,8 @@ const validCodeAllImports = `
   import someInternalHelper from 'helpers/someHelper';
   import someInternalUtil from 'utils/someUtil';
 
+  import SomethingFromIndex from '.';
+  import SomethingFromIndexAbove from '..';
   import SomethingFromRelativePath from '../../Something';
   import AnotherThingFromRelativePath from '../AnotherThing';
   import AndOneMoreThingFromRelativePath from './AndOneMoreThing';
@@ -64,6 +66,7 @@ const validCodeSomeImports = `
   import someInternalHelper from 'helpers/someHelper';
   import someInternalUtil from 'utils/someUtil';
 
+  import SomethingFromIndexAbove from '..';
   import SomethingFromRelativePath from '../../Something';
   import AndOneMoreThingFromRelativePath from './AndOneMoreThing';
 `;


### PR DESCRIPTION
### **What does this PR do?**

When importing from an index file is valid to omit the `/` character like:

```js
import FromIndex from '.';
import AnotherThingFromIndex from '..';
```

This was causing a bug in the `quintoandar-import-rule` where these relative imports were not being handled correctly by lint and auto-fix. This PR fixes this by changing the relative import regex.