### PR TITLE
Create no-var-message-id eslint rule

### DIFF
--- a/eslint-plugin-quintoandar/index.js
+++ b/eslint-plugin-quintoandar/index.js
@@ -19,6 +19,7 @@ module.exports = {
     'no-block-party-waffle-menu-import': require('./rules/no-block-party-waffle-menu'),
     'no-block-party-cozy-components': require('./rules/no-block-party-cozy-components'),
     'no-default-message': require('./rules/no-default-message'),
+    'no-var-message-id': require('./rules/no-var-message-id'),
     'quintoandar-import-order': require('./rules/quintoandar-import-order'),
   },
   configs: {
@@ -38,6 +39,7 @@ module.exports = {
         'no-block-party-waffle-menu-import': 2,
         'no-block-party-cozy-components': 2,
         'no-default-message': 2,
+        'no-var-message-id': 2,
         'quintoandar-import-order': 2,
       },
     },

--- a/eslint-plugin-quintoandar/package-lock.json
+++ b/eslint-plugin-quintoandar/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/eslint-plugin-quintoandar/package.json
+++ b/eslint-plugin-quintoandar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-quintoandar",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "An eslint-plugin for PWA-Tenants custom rules",
   "main": "index.js",
   "scripts": {

--- a/eslint-plugin-quintoandar/rules/no-var-message-id.js
+++ b/eslint-plugin-quintoandar/rules/no-var-message-id.js
@@ -1,0 +1,46 @@
+const defineMessagesFunctionName = 'defineMessages';
+const objectExpressionType = 'ObjectExpression';
+const propertyType = 'Property';
+const literalType = 'Literal';
+
+const reportText = `
+  Do not use variables on message id.
+  This prevent us from generating messages with static code analysis.
+
+  See more: https://guidelines.quintoandar.com.br/#/pwa/internationalization
+`;
+
+const isDefineMessages = (node) => node.callee.name === defineMessagesFunctionName;
+const hasArguments = (node) => node.arguments && node.arguments.length;
+const hasProperties = (node) =>  node.arguments[0].type === objectExpressionType && node.arguments[0].properties;
+const isProperty = (property) => property.type === propertyType;
+const hasMessageProps = (property) => property.value.type === objectExpressionType && property.value.properties;
+const isValueLiteral = (property) => property.value.type === literalType;
+
+module.exports = function noVarMessageId(context) {
+  return {
+    CallExpression(node) {
+      if (!isDefineMessages(node) || !hasArguments(node) || !hasProperties(node)) {
+        return;
+      }
+
+      const jsonObject = node.arguments[0].properties;
+
+      jsonObject.forEach((jsonNode) => {
+        if (!isProperty(jsonNode) || !hasMessageProps(jsonNode)) {
+          return;
+        }
+
+        const message = jsonNode.value.properties;
+        const idField = message.find(x => x.key.name === 'id');
+
+        if (!isValueLiteral(idField)) {
+          context.report({
+            node,
+            message: reportText,
+          });
+        }
+      });
+    }
+  };
+};

--- a/eslint-plugin-quintoandar/rules/tests/no-var-message-id.test.js
+++ b/eslint-plugin-quintoandar/rules/tests/no-var-message-id.test.js
@@ -1,0 +1,39 @@
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../no-var-message-id');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 8,
+  sourceType: 'module',
+  ecmaFeatures: {
+    experimentalObjectRestSpread: true,
+    jsx: true,
+  },
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const reportText = `
+  Do not use variables on message id.
+  This prevent us from generating messages with static code analysis.
+
+  See more: https://guidelines.quintoandar.com.br/#/pwa/internationalization
+`;
+
+const errors = [{ reportText }];
+
+const ruleTester = new RuleTester({ parserOptions });
+ruleTester.run('no-var-message-id', rule, {
+  invalid: [
+    { code: "export default defineMessages({ title: { id: `${test}`, defaultMessage: 'test invalid message' } })", errors }
+  ],
+  valid: [
+    { code: "export default defineMessages({ title: { id: 'valid id', defaultMessage: 'test valid message' } })"},
+    { code: "export default otherFunction({ title: { id: `${test}`, defaultMessage: 'test other function' } })"}
+  ],
+});


### PR DESCRIPTION
# What does this PR do?

It creates a lint rule to fail the build when there is a variable on the messages' id.

# Why 
Using variables as an id prevents us from generating messages with static code analysis.